### PR TITLE
allows ip addresses to be given as a range in allowable ip array

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\HttpFoundation\Request;
 use AppKernel;
+use Symfony\Component\HttpFoundation\IpUtils;
 
 /**
  * Class DefaultController
@@ -106,7 +107,8 @@ class DefaultController extends Controller
         $this->lockfile = $this->get('kernel')->getRootDir()."/../composer.lock";
         $this->isCloudFlare = ($request->query->get('server') == "cloudflare-nginx" ? true : false);
 
-        if ($key != $this->access_key || (!in_array($this->remote_address,$this->allowableIps) || !$this->isCloudFlare)) {
+        // Verify Access Key and IP Address
+        if ($key != $this->access_key || !IpUtils::checkIp($this->remote_address, $this->allowableIps)) {
           $this->sendSecurityReport(NULL, TRUE);
           throw new UnauthorizedHttpException("You are not authorized to access this.");
         }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Symfony 3 bundle for automating reports with the Symfony security checker comp
 
 ##Installation##
 Add the following to your composer.json file.
-    
+
 ```
 "require": {
     ...
@@ -48,7 +48,7 @@ treetop1500_security_report:
 
 `key` can be any alpha-numeric string that you will pass to this service as a url parameter.
 
-`allowable_ips` is an array of IP addresses that can access this service.
+`allowable_ips` is an array of IP addresses that can access this service. Can be given as a single IP or in CIDR notation (x.x.x.x/xx)
 
 `show_output` should be set to false in production environments. Set to true when accessing the page manaually for debugging.
 
@@ -87,4 +87,3 @@ If you use EasyCron, the IP addresses you need can be found here: https://www.ea
 2. Improve Email subject based on results
 3. Explore priority email headers
 4. Add a configuration setting to allow only emails to be sent on tests that reveal vulnerabilities ("OK" results are not emailed).
-


### PR DESCRIPTION
Our last revision didn't work out. I think our logic wasn't working out there with the OR statement. So I looked into a way where I could just add the Cloudflare IPs as they are listed here...

https://www.cloudflare.com/ips

Mainly, allowing something like 103.21.244.0/22.

So I used this...

http://api.symfony.com/2.8/Symfony/Component/HttpFoundation/IpUtils.html#method_checkIp

It seems to be working on my end. Let me know if you see any issues with this approach.
