### PR TITLE
updating composer.json requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.4.0",
         "symfony/symfony": ">=2.8",
-        "sensiolabs/security-checker": "~3.0"
+        "sensiolabs/security-checker": ">=3.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
 In latest version of Symfony 3, sensiolabs/security-checker 4.0 is being used. We were requiring 3.0. Changed it to require >= 3.0. 