### PR TITLE
Added Symfony Command

### DIFF
--- a/Command/SecurityCheckCommand.php
+++ b/Command/SecurityCheckCommand.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: grayloon
+ * Date: 3/2/18
+ * Time: 2:04 PM
+ */
+
+namespace Treetop1500\SecurityReportBundle\Command;
+
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SecurityCheckCommand extends ContainerAwareCommand
+{
+  /**
+   * @var string
+   * how the report is delivered (email, eventually slack)
+   */
+  private $deliveryMethod;
+  
+  /**
+   * @var boolean
+   * whether to show the output in the view. Useful during development, but should be set to false in production
+   */
+  private $showOutput;
+  
+  /**
+   * @var array
+   * array of recipients to receive reports
+   */
+  private $email_recipients;
+  
+  /**
+   * @var string
+   * email sender
+   */
+  private $email_from;
+  
+  /**
+   * @var boolean
+   * when set to true, will not send Status OK results
+   */
+  private $advisories_only;
+  
+  /**
+   * @var string
+   * The path to the composer.lock file used in the security:check command
+   */
+  private $lockfile;
+  
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure()
+  {
+    $this
+      ->setName('treetop:report')
+      ->setDescription('Check project dependencies for security issues');
+  }
+  
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $config = $this->getContainer()->getParameter('treetop1500_security_report.config');
+    $this->showOutput = $config['show_output'];
+    $this->deliveryMethod = $config['delivery_method'];
+    $this->email_recipients = $config['email_recipients'];
+    $this->email_from = $config['email_from'];
+    $this->advisories_only = $config['advisories_only'];
+    $this->lockfile = $this->getContainer()->get('kernel')->getRootDir()."/../composer.lock";
+    
+    $command = $this->getApplication()->find('security:check');
+    
+    $input = new ArrayInput(array('command' => 'security:check', 'lockfile' => $this->lockfile));
+    
+    $buffOut = new BufferedOutput();
+  
+    $command->run($input, $buffOut);
+    
+    $content = $buffOut->fetch();
+    // check advisory setting before sending email
+    if (($this->advisoriesExist($content) && $this->advisories_only) || !$this->advisories_only) {
+      $this->sendSecurityReport($content);
+    }
+  }
+  
+  
+  /**
+   * @param $content string
+   * @return bool
+   * checks if the result of the security:check command contains an [OK] status or not.
+   */
+  private function advisoriesExist($content)
+  {
+    if (preg_match('/\[OK\]/', $content)) {
+      return false;
+    }
+    
+    return true;
+  }
+  
+  /**
+   * @param $content
+   * @param bool $error
+   * Sends the notification with Swiftmailer. If error, then a notification will be sent.
+   * If not the report results are sent.
+   */
+  private function sendSecurityReport($content, $error = false)
+  {
+    $host = $this->getContainer()->get('router')->getContext()->getHost();
+    
+    if (!$error) {
+      $message = \Swift_Message::newInstance()
+        ->setSubject('New Security Check Report')
+        ->setFrom($this->email_from)
+        ->setTo($this->email_recipients)
+        ->setBody(
+          $this->getContainer()->get('templating')->render(
+            'Treetop1500SecurityReportBundle:Default:report.html.twig',
+            array(
+              'report' => $content,
+              'host' => $host
+            )
+          ),
+          'text/html'
+        );
+    }
+    $this->getContainer()->get('mailer')->send($message);
+  }
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A Symfony 3 bundle for automating reports with the Symfony security checker comp
 
 *Please note: This bundle is not ready for public use yet, and is not in the Packagist repository, so the composer installation below will not work yet.*
 
-##Installation##
+##Installation
 Add the following to your composer.json file.
 
 ```
@@ -46,9 +46,9 @@ treetop1500_security_report:
 
 ```
 
-`key` can be any alpha-numeric string that you will pass to this service as a url parameter.
+`key` can be any alpha-numeric string that you will pass to this service as a url parameter. This is ony required if you're not using the symfony command.
 
-`allowable_ips` is an array of IP addresses that can access this service. Can be given as a single IP or in CIDR notation (x.x.x.x/xx)
+`allowable_ips` is an array of IP addresses that can access this service. Can be given as a single IP or in CIDR notation (x.x.x.x/xx). This is ony required if you're not using the symfony command.
 
 `show_output` should be set to false in production environments. Set to true when accessing the page manaually for debugging.
 
@@ -71,12 +71,18 @@ treetop1500_security_report:
     resource: "@Treetop1500SecurityReportBundle/Resources/config/routing.yml"
 ```
 
+This is ony required if you're not using the symfony command.
+
 ##Usage##
 
 To run the security report, simply access the url from any configured allowable IP (replace 'XXXXX' with your configured key):
 
     http://mydomain.com/services/security-checker/XXXXX
 
+To run the report command use:
+
+    bin/console treetop:report
+    
 ###Crons###
 It is recommended to set up a cron to run this checker periodically to alert you of new vulnerabilities. Make sure to add the IP addresses of the remote that the cron will be using.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A Symfony 3 bundle for automating reports with the Symfony security checker comp
 
 *Please note: This bundle is not ready for public use yet, and is not in the Packagist repository, so the composer installation below will not work yet.*
 
-##Installation
+## Installation
 Add the following to your composer.json file.
 
 ```
@@ -29,7 +29,7 @@ public function registerBundles()
 
 Then run `composer update`
 
-##Configuration##
+## Configuration
 
 Add the following to your config:
 
@@ -61,7 +61,7 @@ treetop1500_security_report:
 `advisories_only` should be set to true if you want only reports containing advisories. Set to false to be notified of all reports. Default is false.
 
 
-##Routing##
+## Routing
 
 Import the routing:
 
@@ -73,7 +73,7 @@ treetop1500_security_report:
 
 This is ony required if you're not using the symfony command.
 
-##Usage##
+## Usage
 
 To run the security report, simply access the url from any configured allowable IP (replace 'XXXXX' with your configured key):
 
@@ -83,12 +83,12 @@ To run the report command use:
 
     bin/console treetop:report
     
-###Crons###
+### Crons
 It is recommended to set up a cron to run this checker periodically to alert you of new vulnerabilities. Make sure to add the IP addresses of the remote that the cron will be using.
 
 If you use EasyCron, the IP addresses you need can be found here: https://www.easycron.com/ips
 
-###To Do###
+### To Do
 1. Complete phpUnit testing suite
 2. Improve Email subject based on results
 3. Explore priority email headers


### PR DESCRIPTION
Added a symfony command to run the report check and send an email. Uses the same configuration keys as the controller option. To run the command use

`bin/console treeptop:report`